### PR TITLE
Update Members.md

### DIFF
--- a/Members.md
+++ b/Members.md
@@ -1,9 +1,13 @@
-# Members of the TSC
+# Members of the ISIS TC
 
+- [Andrew Annex](https://github.com/AndrewAnnex)
 - [Michael Aye](https://github.com/michaelaye)
 - [Ross Beyer](https://github.com/rbeyer)
+- [Mario D'Amore]
+- [Audrie Fennema](https://github.com/audiefen)
+- [Robin Fergason](https://github.com/rfergason)
 - [Jay Laura](https://github.com/jlaura)
 - [Jesse Mapel](https://github.com/jessemapel)
+- [Stuart Robbins](https://github.com/astrostu)
 - [Victor Silva](https://github.com/victoronline)
 - [Summer Stapleton](https://github.com/SgStapleton)
-- [Andrew Annex](https://github.com/AndrewAnnex)

--- a/Members.md
+++ b/Members.md
@@ -3,11 +3,10 @@
 - [Andrew Annex](https://github.com/AndrewAnnex)
 - [Michael Aye](https://github.com/michaelaye)
 - [Ross Beyer](https://github.com/rbeyer)
-- [Mario D'Amore]
+- [Mario D'Amore](https://github.com/kidpixo)
 - [Audrie Fennema](https://github.com/audiefen)
 - [Robin Fergason](https://github.com/rfergason)
 - [Jay Laura](https://github.com/jlaura)
 - [Jesse Mapel](https://github.com/jessemapel)
 - [Stuart Robbins](https://github.com/astrostu)
 - [Victor Silva](https://github.com/victoronline)
-- [Summer Stapleton](https://github.com/SgStapleton)


### PR DESCRIPTION
I updated the member list to include those who attended today's ISIS TC meeting.   I also included those who indicated through Issue #54 "ISIS Technical Committee Membership" that they wanted to be a member of the TC.  However, I do not know who kidpixo is, so they are not explicitly included in the member list.  @kidpixo - please edit this PR to indicate your name and membership.  Thanks!