### PR TITLE
Added TSC application to February Agenda

### DIFF
--- a/meetings/2020-02-11.md
+++ b/meetings/2020-02-11.md
@@ -9,6 +9,7 @@
 
 ## Agenda / Notes
  - Contributing documents
+ - Applying to the Planetary Software TSC as a top level project
 
 ## Discussions for next meeting
  -


### PR DESCRIPTION
Applying to the Planetary Software TSC is a big part of why this group was started in the first place. We should talk about what this means and what is needed to do this.

[Top level projects](https://github.com/planetarysoftware/TSC/blob/master/Projects.md)

[Application template](https://github.com/planetarysoftware/TSC/blob/master/Applications/Template.md)

I see this as largely a formality because we have already adopted the TSC governance docs as a starting point.