### PR TITLE
Application process

### DIFF
--- a/meetings/2020-05-12.md
+++ b/meetings/2020-05-12.md
@@ -11,6 +11,10 @@
  - Action Items from last meeting
    - Add landing at .gov website, can redirect to github. Jesse will ensure this gets assigned and scheduled (ASC)
    - Come up with a way for people to apply to the TC (Jesse)
+     - Create a new issue with listed requirements and process
+     - Link to issue in readme
+     - Applicants post on issue if they are interested
+     - Applicants are voted on at the next TC meeting
    - Generate a rough Authors list (Andrew)
    - Look at issue [#94](https://github.com/USGS-Astrogeology/ISIS_TC/issues/94) and [#95](https://github.com/USGS-Astrogeology/ISIS_TC/issues/95) (all)
 


### PR DESCRIPTION
Since I'm going to be out for the meeting, I'm adding where I'm at on applying to join the TC.

I've also considered adding a link on the ISIS repo, but I think we need something more robust than just a link describing the TC there.