### PR TITLE
Added September meeting stub

### DIFF
--- a/meetings/2020-07-14.md
+++ b/meetings/2020-07-14.md
@@ -1,0 +1,29 @@
+# ISIS TC Meeting July 14, 2020 @12PM MST
+
+## [Teams Link](https://teams.microsoft.com/dl/launcher/launcher.html?url=%2f_%23%2fl%2fmeetup-join%2f19%3ameeting_YWRkZjdiMGUtZWJlOC00OWMzLThlMTItZTk0Y2MyM2E1MWE0%40thread.v2%2f0%3fcontext%3d%257b%2522Tid%2522%253a%25220693b5ba-4b18-4d7b-9341-f32f400a5494%2522%252c%2522Oid%2522%253a%2522c27c6e98-e45a-45ff-aea5-7f10d6fe67c1%2522%257d%26anon%3dtrue&type=meetup-join&deeplinkId=e54b3969-3c7f-4efb-9cad-ee99cf639f86&directDl=true&msLaunch=true&enableMobilePage=true&suppressPrompt=true)
+
+### Attending
+-
+
+## Agenda / Notes
+- Action Items from last meeting
+  - JLaura will open a PR on the ISIS3 repo with a draft policy / discussion and then go from there
+  - JLaura, next retro discuss the LTS model and release velocity; RBeyer will open an issue on the TC repo to get this discussed
+  - JLaura will PR in the meeting notes
+  - AAnnex can add a PR that updates the PR template
+  - JMapel can add to the release docs to have the authors list can be updated
+  - JLaura can check with zenodo to see about getting the authors file updated correctly when we do a release. He will determine what needs to be done manually and can then update the release procedure docs.
+
+- Long term support, release velocity
+
+- Issue lifecycle
+
+
+## Discussions for next meeting
+-
+
+## Action Items
+-
+
+## Next Meeting
+- August 11th @ 12pm MST


### PR DESCRIPTION
I removed the meeting notes google doc as people aren't all editing at the same time and it require extra Copy/Paste stuff. Instead, I'll be just taking notes in my editor and then PR'ing after the meeting.