### PR TITLE
Remove Kristin Berry from Members list

### DIFF
--- a/Members.md
+++ b/Members.md
@@ -3,7 +3,6 @@
 - [Andrew Annex](https://github.com/AndrewAnnex)
 - [Michael Aye](https://github.com/michaelaye)
 - [Kris Becker](https://github.com/KrisBecker)
-- [Kristin Berry](https://github.com/kberryUSGS)
 - [Ross Beyer](https://github.com/rbeyer)
 - [Mario D'Amore](https://github.com/kidpixo)
 - [Audrie Fennema](https://github.com/audiefen)


### PR DESCRIPTION
I'm leaving the USGS, so I am resigning from the ISIS TC. This PR removes my name from the members list. It's been great working with all of you!